### PR TITLE
Added the ability to apply shimmer effect on static views when loading dynamic ones

### DIFF
--- a/Shared/AppView/DummyExampleView.swift
+++ b/Shared/AppView/DummyExampleView.swift
@@ -1,0 +1,31 @@
+//
+//  DummyExampleView.swift
+//  ShimmerEffect (iOS)
+//
+//  Created by Cédric Bahirwe on 14/08/2022.
+//
+
+import SwiftUI
+
+struct DummyExampleView: View {
+    @State private var isRedacted = true
+    
+    var body: some View {
+        ScrollView {
+            DummyModelRowView(model: .default)
+                .redacted(when: isRedacted)
+            Button {
+                isRedacted.toggle()
+            } label: {
+                Text("Toggle redacted...")
+            }
+            
+        }
+    }
+}
+
+struct DummyExampleView_Previews: PreviewProvider {
+    static var previews: some View {
+        DummyExampleView()
+    }
+}

--- a/Shared/AppView/ShimmerEffectEntryView.swift
+++ b/Shared/AppView/ShimmerEffectEntryView.swift
@@ -21,10 +21,18 @@ struct ShimmerEffectEntryView: View {
 
                 NavigationLink(
                     destination: ExampleView()
-                        .navigationTitle("Example and usage")
+                        .navigationTitle("Example and usage 1")
                         .navigationBarTitleDisplayMode(.inline)
                 ) {
-                    Text("Example and usage")
+                    Text("Example and usage 1")
+                }
+
+                NavigationLink(
+                    destination: DummyExampleView()
+                        .navigationTitle("Example and usage 2")
+                        .navigationBarTitleDisplayMode(.inline)
+                ) {
+                    Text("Example and usage 2")
                 }
             }
             .navigationTitle("Navigation")

--- a/Shared/Models/DummyModel.swift
+++ b/Shared/Models/DummyModel.swift
@@ -1,0 +1,22 @@
+//
+//  DummyModel.swift
+//  ShimmerEffect (iOS)
+//
+//  Created by Cédric Bahirwe on 14/08/2022.
+//
+
+import Foundation
+
+struct DummyModel {
+    let image: String
+    let title: String
+    let description: String
+
+    static let `default` = DummyModel(image: "person.circle",
+                                      title: "Lorem Ipsum",
+                                      description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book")
+
+    static let sample = DummyModel(image: "house.fill",
+                                   title: "The best title ever",
+                                   description: "This is a description to showcase how providing a dummy data when the view is loading.")
+}

--- a/Shared/Protocols/ShimmerRedactableView.swift
+++ b/Shared/Protocols/ShimmerRedactableView.swift
@@ -1,0 +1,14 @@
+//
+//  ShimmerRedactableView.swift
+//  ShimmerEffect (iOS)
+//
+//  Created by Cédric Bahirwe on 14/08/2022.
+//
+
+import SwiftUI
+
+public protocol ShimmerRedactableView: View {
+    associatedtype ShimmerView: View
+
+    @ViewBuilder static var shimmerView: Self.ShimmerView { get }
+}

--- a/Shared/UltilityView/DummyModelRowView.swift
+++ b/Shared/UltilityView/DummyModelRowView.swift
@@ -1,0 +1,34 @@
+//
+//  DummyModelRowView.swift
+//  ShimmerEffect (iOS)
+//
+//  Created by Cédric Bahirwe on 14/08/2022.
+//
+
+import SwiftUI
+
+struct DummyModelRowView: ShimmerRedactableView {
+    static var shimmerView: some View { DummyModelRowView(model: .sample) }
+    let model: DummyModel
+    var body: some View {
+        VStack {
+            Image(systemName: model.image)
+                .resizable()
+                .frame(width: 100, height: 100)
+            VStack(spacing: 10) {
+                Text(model.title)
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .foregroundColor(Color.blue)
+                Text(model.description)
+            }
+        }
+        .padding()
+    }
+}
+
+struct DummyModelRowView_Previews: PreviewProvider {
+    static var previews: some View {
+        DummyModelRowView(model: .default)
+    }
+}

--- a/Shared/ViewModifier/Shimmer/GenericShimmerRedViewModifier.swift
+++ b/Shared/ViewModifier/Shimmer/GenericShimmerRedViewModifier.swift
@@ -1,0 +1,47 @@
+//
+//  GenericShimmerRedViewModifier.swift
+//  ShimmerEffect (iOS)
+//
+//  Created by Cédric Bahirwe on 14/08/2022.
+//
+
+import SwiftUI
+
+public struct GenericShimmerRedViewModifier<T: ShimmerRedactableView>: ViewModifier {
+    private var shimmerView: T.ShimmerView
+    @State private var progress: CGFloat = 0
+    private let configuration: ShimmerConfiguration
+    private let condition: Bool
+
+    init(shimmerView: T.ShimmerView,
+        condition: Bool,
+        configuration: ShimmerConfiguration = .default
+    ) {
+        self.shimmerView = shimmerView
+        self.condition = condition
+        self.configuration = configuration
+    }
+
+    public func body(content: Content) -> some View {
+        content
+            .if(condition) { _ in
+                shimmerView
+                    .redacted(reason: .placeholder)
+                    .modifier(
+                        ShimmerAnimation(
+                            progress: progress,
+                            configuration: configuration
+                        )
+                            .animation(
+                                Animation.linear(duration: configuration.duration).repeatForever(autoreverses: false)
+                            )
+                    )
+                    .onAppear {
+                        progress = 1 + configuration.effectRadius
+                    }
+                    .onDisappear {
+                        progress = 0
+                    }
+            }
+    }
+}

--- a/Shared/ViewUtility/RedactedView.swift
+++ b/Shared/ViewUtility/RedactedView.swift
@@ -18,3 +18,14 @@ extension View {
         )
     }
 }
+
+extension View where Self: ShimmerRedactableView {
+    func redacted(when condition: Bool) -> some View {
+        modifier(
+            GenericShimmerRedViewModifier<Self>(shimmerView: Self.shimmerView,
+                                                condition: condition,
+                                                configuration: .default)
+        )
+    }
+
+}

--- a/ShimmerEffect.xcodeproj/project.pbxproj
+++ b/ShimmerEffect.xcodeproj/project.pbxproj
@@ -19,6 +19,11 @@
 		AD5B4641287A25D900E83C87 /* ShimmerViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5B4640287A25D900E83C87 /* ShimmerViewModifier.swift */; };
 		AD5B4645287A289000E83C87 /* DummyRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5B4644287A289000E83C87 /* DummyRowView.swift */; };
 		AD5B4647287A2A3100E83C87 /* ExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5B4646287A2A3100E83C87 /* ExampleView.swift */; };
+		CB45380028A93A4C00F3F24C /* ShimmerRedactableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4537FF28A93A4C00F3F24C /* ShimmerRedactableView.swift */; };
+		CB45380328A93C1A00F3F24C /* GenericShimmerRedViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB45380228A93C1900F3F24C /* GenericShimmerRedViewModifier.swift */; };
+		CB45380828A93CE600F3F24C /* DummyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB45380728A93CE600F3F24C /* DummyModel.swift */; };
+		CB45380A28A93D9800F3F24C /* DummyModelRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB45380928A93D9800F3F24C /* DummyModelRowView.swift */; };
+		CB45380C28A93E1400F3F24C /* DummyExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB45380B28A93E1400F3F24C /* DummyExampleView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,6 +40,11 @@
 		AD5B4640287A25D900E83C87 /* ShimmerViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerViewModifier.swift; sourceTree = "<group>"; };
 		AD5B4644287A289000E83C87 /* DummyRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyRowView.swift; sourceTree = "<group>"; };
 		AD5B4646287A2A3100E83C87 /* ExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleView.swift; sourceTree = "<group>"; };
+		CB4537FF28A93A4C00F3F24C /* ShimmerRedactableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerRedactableView.swift; sourceTree = "<group>"; };
+		CB45380228A93C1900F3F24C /* GenericShimmerRedViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericShimmerRedViewModifier.swift; sourceTree = "<group>"; };
+		CB45380728A93CE600F3F24C /* DummyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyModel.swift; sourceTree = "<group>"; };
+		CB45380928A93D9800F3F24C /* DummyModelRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyModelRowView.swift; sourceTree = "<group>"; };
+		CB45380B28A93E1400F3F24C /* DummyExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyExampleView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -52,6 +62,7 @@
 			isa = PBXGroup;
 			children = (
 				AD5B4640287A25D900E83C87 /* ShimmerViewModifier.swift */,
+				CB45380228A93C1900F3F24C /* GenericShimmerRedViewModifier.swift */,
 				AD2F9D5B287D0440008E744B /* ShimmerAnimatableModifier.swift */,
 				AD2F9D59287D040F008E744B /* ShimmerConfiguration.swift */,
 			);
@@ -64,6 +75,7 @@
 				AD2F9D54287B9A04008E744B /* ShimmerEffectEntryView.swift */,
 				AD5B45FE2878C76600E83C87 /* ImplementationStepsView.swift */,
 				AD5B4646287A2A3100E83C87 /* ExampleView.swift */,
+				CB45380B28A93E1400F3F24C /* DummyExampleView.swift */,
 			);
 			path = AppView;
 			sourceTree = "<group>";
@@ -82,6 +94,8 @@
 				AD5B45FD2878C76600E83C87 /* ShimmerEffectApp.swift */,
 				AD2F9D5D287D0684008E744B /* AppView */,
 				AD5B463F287A25C800E83C87 /* ViewModifier */,
+				CB4537FE28A93A3700F3F24C /* Protocols */,
+				CB45380628A93CB700F3F24C /* Models */,
 				AD5B463C287A24D500E83C87 /* ViewUtility */,
 				AD5B4639287A244300E83C87 /* UltilityView */,
 				AD5B45FF2878C76700E83C87 /* Assets.xcassets */,
@@ -102,6 +116,7 @@
 			children = (
 				AD5B463A287A245900E83C87 /* DescriptionView.swift */,
 				AD5B4644287A289000E83C87 /* DummyRowView.swift */,
+				CB45380928A93D9800F3F24C /* DummyModelRowView.swift */,
 			);
 			path = UltilityView;
 			sourceTree = "<group>";
@@ -121,6 +136,22 @@
 				AD2F9D58287D01DB008E744B /* Shimmer */,
 			);
 			path = ViewModifier;
+			sourceTree = "<group>";
+		};
+		CB4537FE28A93A3700F3F24C /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				CB4537FF28A93A4C00F3F24C /* ShimmerRedactableView.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
+		CB45380628A93CB700F3F24C /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				CB45380728A93CE600F3F24C /* DummyModel.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -193,15 +224,20 @@
 			buildActionMask = 2147483647;
 			files = (
 				AD2F9D57287D0038008E744B /* RedactedView.swift in Sources */,
+				CB45380028A93A4C00F3F24C /* ShimmerRedactableView.swift in Sources */,
+				CB45380A28A93D9800F3F24C /* DummyModelRowView.swift in Sources */,
 				AD5B463B287A245900E83C87 /* DescriptionView.swift in Sources */,
 				AD5B463E287A24F400E83C87 /* ConditionalView.swift in Sources */,
 				AD2F9D55287B9A04008E744B /* ShimmerEffectEntryView.swift in Sources */,
 				AD5B4647287A2A3100E83C87 /* ExampleView.swift in Sources */,
 				AD2F9D5A287D040F008E744B /* ShimmerConfiguration.swift in Sources */,
+				CB45380C28A93E1400F3F24C /* DummyExampleView.swift in Sources */,
 				AD5B46272878C76700E83C87 /* ImplementationStepsView.swift in Sources */,
 				AD2F9D5C287D0440008E744B /* ShimmerAnimatableModifier.swift in Sources */,
+				CB45380328A93C1A00F3F24C /* GenericShimmerRedViewModifier.swift in Sources */,
 				AD5B4645287A289000E83C87 /* DummyRowView.swift in Sources */,
 				AD5B4641287A25D900E83C87 /* ShimmerViewModifier.swift in Sources */,
+				CB45380828A93CE600F3F24C /* DummyModel.swift in Sources */,
 				AD5B46252878C76700E83C87 /* ShimmerEffectApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
The intention of this PR is to provide a way, a `Protocol`,  that views can conform to and provide their default  `Shimmer View` via a static property. This can be very handy especially when a view is displaying `remote` data/content

This PR is my humble way to contribute to this lovely project. 

Run code and click `"Example and usage 2" to see the behavior

**Challenges faced**

- Think of a way to use `one` modifier instead of creating another one...
- My naming of new objects is a bit horrible, obviously not a guru in naming 😃
- Optimize when wherever possible (less code is always better )
